### PR TITLE
Adding fix for 20.x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,8 @@ import through2 from 'through2';
 
 const PLUGIN_NAME = 'gulp-jest-cli';
 
-const runCLI = (argv, rootDir, done) => {
-  jest.runCLI(argv, rootDir, (result) => {
+const runCLI = (argv, projects, done) => {
+  jest.runCLI(argv, projects, (result) => {
     if (result.numFailedTestSuites || result.numFailedTests) {
       const error = new PluginError(PLUGIN_NAME, 'Jest failed');
       error.jest = true;
@@ -75,7 +75,7 @@ const plugin = (options = {}) => {
       };
     }
 
-    runCLI(argv, rootDir, done);
+    runCLI(argv, [rootDir], done);
   }
 
   return through2.obj(onceOrThrow);


### PR DESCRIPTION
Adds a quick fix for Jest 20.x per Issue #1 

Made this to where it doesn't break existing functionality but only wraps the previously supplied parameter into an array.

I tried to run the tests locally however and there was some kind of infinite loop, not sure if it was my machine or this PR broke something.